### PR TITLE
add DateFormatted Component and normalizer utility

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/packages/client/src/components/date-formatted/date-formatted.tsx
+++ b/packages/client/src/components/date-formatted/date-formatted.tsx
@@ -1,0 +1,13 @@
+import { FC } from 'react';
+import { normalizeDate } from 'utils/normalizeDate';
+
+//С API приходит строка вида: 2023-02-23T06:48:31+00:00
+type Props = {
+  date?: string;
+};
+
+export const DateFormatted: FC<Props> = ({
+  date = new Date().toISOString(),
+}: Props) => {
+  return <time dateTime={date}>{normalizeDate(date)}</time>;
+};

--- a/packages/client/src/components/date-formatted/date-formatted.tsx
+++ b/packages/client/src/components/date-formatted/date-formatted.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { normalizeDate } from 'utils/normalizeDate';
+import { normalizeDate } from 'utils/normalize-date';
 
 //С API приходит строка вида: 2023-02-23T06:48:31+00:00
 type Props = {

--- a/packages/client/src/components/date-formatted/date-formatted.tsx
+++ b/packages/client/src/components/date-formatted/date-formatted.tsx
@@ -8,6 +8,6 @@ type Props = {
 
 export const DateFormatted: FC<Props> = ({
   date = new Date().toISOString(),
-}: Props) => {
+}) => {
   return <time dateTime={date}>{normalizeDate(date)}</time>;
 };

--- a/packages/client/src/components/date-formatted/index.ts
+++ b/packages/client/src/components/date-formatted/index.ts
@@ -1,0 +1,1 @@
+export { DateFormatted } from './date-formatted';

--- a/packages/client/src/utils/normalize-date.ts
+++ b/packages/client/src/utils/normalize-date.ts
@@ -1,3 +1,9 @@
+const MILLISECONDS = 1000;
+const MINS = 60;
+const SECONDS = 60;
+const HOURS = 24;
+const DAY = MILLISECONDS * MINS * SECONDS * HOURS;
+
 export function normalizeDate(d: string): string {
   //С API приходит строка вида: 2023-02-23T06:48:31+00:00
   const regEx =
@@ -24,7 +30,7 @@ export function normalizeDate(d: string): string {
   let dateToRender = '';
 
   if (
-    now.getTime() - date.getTime() < 1000 * 60 * 60 * 24 * 3 &&
+    now.getTime() - date.getTime() < DAY * 3 &&
     now.getDate() - date.getDate() <= 2
   ) {
     if (now.getDate() === date.getDate()) {

--- a/packages/client/src/utils/normalizeDate.ts
+++ b/packages/client/src/utils/normalizeDate.ts
@@ -1,0 +1,51 @@
+export function normalizeDate(d: string): string {
+  //С API приходит строка вида: 2023-02-23T06:48:31+00:00
+  const regEx =
+    /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})T(?<hour>\d{2}):(?<min>\d{2}):(?<sec>\d{2})/;
+
+  const parsed = d.match(regEx)?.groups;
+  if (!parsed) {
+    return '';
+  }
+
+  const { year, month, day, hour, min, sec } = parsed;
+  const date = new Date(
+    Date.UTC(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+      Number(hour),
+      Number(min),
+      Number(sec)
+    )
+  );
+  const now = new Date(Date.now());
+
+  let dateToRender = '';
+
+  if (
+    now.getTime() - date.getTime() < 1000 * 60 * 60 * 24 * 3 &&
+    now.getDate() - date.getDate() <= 2
+  ) {
+    if (now.getDate() === date.getDate()) {
+      dateToRender += 'Сегодня ';
+    } else if (now.getDate() - date.getDate() === 1) {
+      dateToRender += 'Вчера ';
+    } else {
+      dateToRender += 'Позавчера ';
+    }
+  } else {
+    dateToRender += `${date.toLocaleDateString('ru', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })} `;
+  }
+
+  dateToRender += `${date.getHours().toString().padStart(2, '0')}:${date
+    .getMinutes()
+    .toString()
+    .padStart(2, '0')}`;
+
+  return dateToRender;
+}


### PR DESCRIPTION
### Какую задачу решаем
Компонент DateFormatted
принимает необязательный пропс ```date``` в формате ISO строки - то есть так, как нам приходит с API, возвращает тег time с отформатированным текстовым представлением даты.

не применяет никаких стилей, должен стилизоваться родителем

### Скриншоты/видяшка (если есть)

![Скриншот 23-02-2023 13_33_08](https://user-images.githubusercontent.com/65237410/220882870-8c23941c-8192-450e-a77f-887a1cb603f3.jpg)

### TBD (если есть)
