### PR TITLE
Настройка линтеров

### DIFF
--- a/packages/client/src/components/avatar/avatar.tsx
+++ b/packages/client/src/components/avatar/avatar.tsx
@@ -15,7 +15,7 @@ export const Avatar: FC<Props> = ({ avatar, name, label, size }) => {
       className={cn(styles.avatar, styles[size])}
       style={{ backgroundImage: `url(${avatar})` }}
     >
-      {!avatar && <p>{name.length ? name[0].toUpperCase() : 'U'}</p>}
+      {!avatar && <p>{name.length > 0 ? name[0].toUpperCase() : 'U'}</p>}
       {label && <span className={cn(styles.label, 'text-menu')}>{label}</span>}
     </div>
   );

--- a/packages/client/src/components/button/button.tsx
+++ b/packages/client/src/components/button/button.tsx
@@ -3,18 +3,18 @@ import { Link, LinkProps } from 'react-router-dom';
 import cn from 'classnames';
 import styles from './button.module.pcss';
 
-enum ButtonColor {
-  gradient = 'gradient',
-  colored = 'colored',
-  light = 'light',
-  icon = 'icon',
+export enum ButtonColor {
+  GRADIENT = 'GRADIENT',
+  COLORED = 'COLORED',
+  LIGHT = 'LIGHT',
+  ICON = 'ICON',
 }
 
-const ButtonColorChoice = {
-  [ButtonColor.gradient]: styles.gradient,
-  [ButtonColor.colored]: styles.colored,
-  [ButtonColor.light]: styles.light,
-  [ButtonColor.icon]: styles.icon,
+const buttonColorChoice = {
+  [ButtonColor.GRADIENT]: styles.gradient,
+  [ButtonColor.COLORED]: styles.colored,
+  [ButtonColor.LIGHT]: styles.light,
+  [ButtonColor.ICON]: styles.icon,
 };
 
 type Props = {
@@ -33,7 +33,7 @@ type ButtonAsButton = Props & JSX.IntrinsicElements['button'];
 
 export const Button: FC<ButtonAsButton> = ({
   type = 'button',
-  color = ButtonColor.colored,
+  color = ButtonColor.COLORED,
   size = 'medium',
   className,
   children,
@@ -43,7 +43,7 @@ export const Button: FC<ButtonAsButton> = ({
     className,
     styles.button,
     styles[size],
-    ButtonColorChoice[color] ?? styles.colored
+    buttonColorChoice[color] ?? styles.colored
   );
 
   return (
@@ -55,7 +55,7 @@ export const Button: FC<ButtonAsButton> = ({
 
 export const ButtonLink: FC<ButtonAsLink> = ({
   to,
-  color = ButtonColor.colored,
+  color = ButtonColor.COLORED,
   size = 'medium',
   className,
   children,
@@ -65,7 +65,7 @@ export const ButtonLink: FC<ButtonAsLink> = ({
     className,
     styles.button,
     styles[size],
-    ButtonColorChoice[color] ?? styles.colored
+    buttonColorChoice[color] ?? styles.colored
   );
 
   return (

--- a/packages/client/src/components/button/index.ts
+++ b/packages/client/src/components/button/index.ts
@@ -1,1 +1,1 @@
-export { Button, ButtonLink } from './button';
+export { Button, ButtonLink, ButtonColor } from './button';

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client';
 import App from './app';
 import './styles/index.pcss';
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+ReactDOM.createRoot(document.querySelector('#root') as HTMLElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>

--- a/packages/client/src/styles/layout.pcss
+++ b/packages/client/src/styles/layout.pcss
@@ -1,4 +1,3 @@
-/* stylelint-disable selector-class-pattern */
 .w-1 {
   width: var(--column);
 }

--- a/packages/client/src/styles/typography.pcss
+++ b/packages/client/src/styles/typography.pcss
@@ -1,4 +1,3 @@
-/* stylelint-disable selector-class-pattern */
 .h1 {
   font-size: 44px;
   font-weight: 700;

--- a/packages/client/src/vite-env.d.ts
+++ b/packages/client/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 /// <reference types="vite-plugin-svgr/client" />
 
 interface ImportMetaEnv {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   readonly VITE_API_BASE_URL: string;
 }
 

--- a/packages/client/stylelint.config.cjs
+++ b/packages/client/stylelint.config.cjs
@@ -45,10 +45,10 @@ module.exports = {
     'selector-max-specificity': '1,3,3', // id,class,type
     'selector-max-compound-selectors': 3,
     'selector-class-pattern': [
-      '^[a-z][a-zA-Z]+$',
+      '^([a-z][a-z0-9]*)(-[a-z0-9]+)*$',
       {
         message: (selector) =>
-          `Expected class selector "${selector}" to be camelCase`,
+          `Expected class selector "${selector}" to be kebab-case`,
       },
     ],
     'selector-id-pattern': [
@@ -68,4 +68,18 @@ module.exports = {
     'plugin/declaration-block-no-ignored-properties': true,
   },
   ignoreFiles: ['public/**/*.css', 'build/**/*.css', 'dist/**/*.css'],
+  overrides: [
+    {
+      files: ['*.module.{css,pcss}'],
+      rules: {
+        'selector-class-pattern': [
+          '^[a-z][a-zA-Z]+$',
+          {
+            message: (selector) =>
+              `Expected class selector "${selector}" to be camelCase`,
+          },
+        ],
+      },
+    },
+  ],
 };

--- a/packages/eslint-config-shared/index.js
+++ b/packages/eslint-config-shared/index.js
@@ -13,7 +13,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 11,
   },
-  plugins: ['@typescript-eslint', 'promise'],
+  plugins: ['@typescript-eslint', 'promise', 'unicorn'],
   overrides: [
     {
       files: ['?(*.)+(spec|test).+(ts|tsx)'],
@@ -33,12 +33,50 @@ module.exports = {
         '@typescript-eslint/no-require-imports': 'off',
       },
     },
+    {
+      files: ['stylelint.config.cjs', '.eslintrc.cjs'],
+      rules: {
+        '@typescript-eslint/naming-convention': 'off',
+      },
+    },
   ],
   rules: {
     // Typescript
     '@typescript-eslint/ban-ts-comment': 'error',
     '@typescript-eslint/no-shadow': 'error',
     '@typescript-eslint/no-require-imports': 'error',
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'variable',
+        leadingUnderscore: 'allowSingleOrDouble',
+        trailingUnderscore: 'allowSingleOrDouble',
+        format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+      },
+      {
+        selector: 'function',
+        leadingUnderscore: 'allow',
+        format: ['camelCase', 'PascalCase'],
+      },
+      {
+        selector: 'property',
+        leadingUnderscore: 'allow',
+        format: ['camelCase'],
+      },
+      {
+        selector: 'method',
+        leadingUnderscore: 'allow',
+        format: ['camelCase'],
+      },
+      {
+        selector: 'enumMember',
+        format: ['UPPER_CASE'],
+      },
+      {
+        selector: 'typeLike',
+        format: ['PascalCase'],
+      },
+    ],
 
     // Problems
     'no-undefined': 'error',
@@ -89,5 +127,33 @@ module.exports = {
     'promise/no-nesting': 'error',
     'promise/no-return-in-finally': 'error',
     'promise/always-return': 'off',
+
+    // Unicorn
+    'unicorn/better-regex': 'error',
+    'unicorn/consistent-destructuring': 'error',
+    'unicorn/no-abusive-eslint-disable': 'error',
+    'unicorn/filename-case': [
+      'error',
+      {
+        case: 'kebabCase',
+      },
+    ],
+    'unicorn/no-instanceof-array': 'error',
+    'unicorn/no-new-array': 'error',
+    'unicorn/no-typeof-undefined': 'error',
+    'unicorn/no-invalid-remove-event-listener': 'error',
+    'unicorn/no-this-assignment': 'error',
+    'unicorn/error-message': 'error',
+    'unicorn/explicit-length-check': 'error',
+    'unicorn/no-unnecessary-await': 'error',
+    'unicorn/no-useless-length-check': 'error',
+    'unicorn/no-useless-undefined': ['error', { checkArguments: false }],
+    'unicorn/prefer-add-event-listener': 'error',
+    'unicorn/prefer-array-flat': 'error',
+    'unicorn/prefer-date-now': 'error',
+    'unicorn/prefer-keyboard-event-key': 'error',
+    'unicorn/prefer-modern-math-apis': 'error',
+    'unicorn/prefer-query-selector': 'error',
+    'unicorn/throw-new-error': 'error',
   },
 };

--- a/packages/eslint-config-shared/package.json
+++ b/packages/eslint-config-shared/package.json
@@ -11,6 +11,7 @@
     "eslint": "8.34.0",
     "eslint-config-prettier": "8.6.0",
     "eslint-plugin-jest": "27.2.1",
-    "eslint-plugin-promise": "6.1.1"
+    "eslint-plugin-promise": "6.1.1",
+    "eslint-plugin-unicorn": "45.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -457,6 +457,13 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz#c5a1a4bfe1b57f0c3e61b29883525c6da3e5c091"
   integrity sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==
 
+"@eslint-community/eslint-utils@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.1.2.tgz#14ca568ddaa291dd19a4a54498badc18c6cfab78"
+  integrity sha512-7qELuQWWjVDdVsFQ5+beUl+KPczrEDA7S3zM4QUd/bJl7oXgsmpXaEVqrRTnOBqenOV4rWf2kVZk2Ot085zPWA==
+  dependencies:
+    eslint-visitor-keys "^3.3.0"
+
 "@eslint/eslintrc@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"
@@ -676,44 +683,23 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
-"@jest/test-sequencer@^28.1.3":
-  version "28.1.3"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-28.1.3.tgz#9d0c283d906ac599c74bde464bc0d7e6a82886c3"
-  integrity sha512-NIMPEqqa59MWnDi1kvXXpYbqsfQmSJsIbnd85mdVGkiDfQ9WQQTXOLsvISUfonmnBT+w85WEgneCigEEdHDFxw==
+"@jest/test-sequencer@^29.4.3":
+  version "29.4.3"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-29.4.3.tgz#0862e876a22993385a0f3e7ea1cc126f208a2898"
+  integrity sha512-yi/t2nES4GB4G0mjLc0RInCq/cNr9dNwJxcGg8sslajua5Kb4kmozAc+qPLzplhBgfw1vLItbjyHzUN92UXicw==
   dependencies:
-    "@jest/test-result" "^28.1.3"
+    "@jest/test-result" "^29.4.3"
     graceful-fs "^4.2.9"
-    jest-haste-map "^28.1.3"
+    jest-haste-map "^29.4.3"
     slash "^3.0.0"
 
-"@jest/transform@^28.1.3":
-  version "28.1.3"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-28.1.3.tgz#59d8098e50ab07950e0f2fc0fc7ec462371281b0"
-  integrity sha512-u5dT5di+oFI6hfcLOHGTAfmUxFRrjK+vnaP0kkVow9Md/M7V/MxqQMOz/VV25UZO8pzeA9PjfTpOu6BDuwSPQA==
+"@jest/transform@^29.4.3":
+  version "29.4.3"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.4.3.tgz#f7d17eac9cb5bb2e1222ea199c7c7e0835e0c037"
+  integrity sha512-8u0+fBGWolDshsFgPQJESkDa72da/EVwvL+II0trN2DR66wMwiQ9/CihaGfHdlLGFzbBZwMykFtxuwFdZqlKwg==
   dependencies:
     "@babel/core" "^7.11.6"
-    "@jest/types" "^28.1.3"
-    "@jridgewell/trace-mapping" "^0.3.13"
-    babel-plugin-istanbul "^6.1.1"
-    chalk "^4.0.0"
-    convert-source-map "^1.4.0"
-    fast-json-stable-stringify "^2.0.0"
-    graceful-fs "^4.2.9"
-    jest-haste-map "^28.1.3"
-    jest-regex-util "^28.0.2"
-    jest-util "^28.1.3"
-    micromatch "^4.0.4"
-    pirates "^4.0.4"
-    slash "^3.0.0"
-    write-file-atomic "^4.0.1"
-
-"@jest/transform@^29.0.1":
-  version "29.0.1"
-  resolved "https://registry.npmjs.org/@jest/transform/-/transform-29.0.1.tgz"
-  integrity sha512-6UxXtqrPScFdDhoip8ys60dQAIYppQinyR87n9nlasR/ZnFfJohKToqzM29KK4gb9gHRv5oDFChdqZKE0SIhsg==
-  dependencies:
-    "@babel/core" "^7.11.6"
-    "@jest/types" "^29.0.1"
+    "@jest/types" "^29.4.3"
     "@jridgewell/trace-mapping" "^0.3.15"
     babel-plugin-istanbul "^6.1.1"
     chalk "^4.0.0"
@@ -2227,6 +2213,11 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
+builtin-modules@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
+  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
+
 builtins@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
@@ -2370,7 +2361,7 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-info@^3.2.0:
+ci-info@^3.2.0, ci-info@^3.6.1:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
@@ -2384,6 +2375,13 @@ classnames@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
+clean-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clean-regexp/-/clean-regexp-1.0.0.tgz#8df7c7aae51fd36874e8f8d05b9180bc11a3fed7"
+  integrity sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -3018,11 +3016,6 @@ dotenv@16.0.2:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.2.tgz#0b0f8652c016a3858ef795024508cddc4bffc5bf"
   integrity sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==
 
-dotenv@^16.0.2:
-  version "16.0.3"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
-  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
-
 dotenv@~10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
@@ -3346,6 +3339,28 @@ eslint-plugin-react@7.32.2:
     resolve "^2.0.0-next.4"
     semver "^6.3.0"
     string.prototype.matchall "^4.0.8"
+
+eslint-plugin-unicorn@^45.0.2:
+  version "45.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-45.0.2.tgz#d6ba704793a6909fe5dfe013900d2b05b715284c"
+  integrity sha512-Y0WUDXRyGDMcKLiwgL3zSMpHrXI00xmdyixEGIg90gHnj0PcHY4moNv3Ppje/kDivdAy5vUeUr7z211ImPv2gw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.19.1"
+    "@eslint-community/eslint-utils" "^4.1.2"
+    ci-info "^3.6.1"
+    clean-regexp "^1.0.0"
+    esquery "^1.4.0"
+    indent-string "^4.0.0"
+    is-builtin-module "^3.2.0"
+    jsesc "^3.0.2"
+    lodash "^4.17.21"
+    pluralize "^8.0.0"
+    read-pkg-up "^7.0.1"
+    regexp-tree "^0.1.24"
+    regjsparser "^0.9.1"
+    safe-regex "^2.1.1"
+    semver "^7.3.8"
+    strip-indent "^3.0.0"
 
 eslint-scope@^5.1.1:
   version "5.1.1"
@@ -4403,6 +4418,13 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
+is-builtin-module@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.1.tgz#f03271717d8654cfcaf07ab0463faa3571581169"
+  integrity sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==
+  dependencies:
+    builtin-modules "^3.3.0"
+
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
@@ -5129,6 +5151,16 @@ jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+jsesc@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
+  integrity sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==
+
+jsesc@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
+  integrity sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==
 
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
@@ -6660,6 +6692,11 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 postcss-media-query-parser@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
@@ -7084,6 +7121,11 @@ regenerator-runtime@^0.13.11:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
+regexp-tree@^0.1.24, regexp-tree@~0.1.1:
+  version "0.1.24"
+  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.24.tgz#3d6fa238450a4d66e5bc9c4c14bb720e2196829d"
+  integrity sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==
+
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
@@ -7097,6 +7139,13 @@ regexpp@^3.0.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
+
+regjsparser@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.9.1.tgz#272d05aa10c7c1f67095b1ff0addae8442fc5709"
+  integrity sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==
+  dependencies:
+    jsesc "~0.5.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -7223,6 +7272,13 @@ safe-regex-test@^1.0.0:
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
 
+safe-regex@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-2.1.1.tgz#f7128f00d056e2fe5c11e81a1324dd974aadced2"
+  integrity sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==
+  dependencies:
+    regexp-tree "~0.1.1"
+
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -7254,7 +7310,7 @@ semver@7.3.4:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
+semver@7.x, semver@^7.0.0, semver@^7.1.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==


### PR DESCRIPTION
## eslint
- добавил [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn) для линтинга потенциальных ошибок в рантайме.
- настроил линтинг именований в коде, в ревью часто сталкиваемся с неконсистентностью, пускай этим занимается линтер.
## stylelint
настроил чтобы правило camelCase селекторов применялось только для css-модулей. 