### PR TITLE
добавляет хук useFullScreen

### DIFF
--- a/packages/client/src/components/fullscreen-button/fullscreen-button.module.pcss
+++ b/packages/client/src/components/fullscreen-button/fullscreen-button.module.pcss
@@ -1,0 +1,4 @@
+.button {
+  height: 48px;
+  align-self: center;
+}

--- a/packages/client/src/components/fullscreen-button/fullscreen-button.tsx
+++ b/packages/client/src/components/fullscreen-button/fullscreen-button.tsx
@@ -1,4 +1,4 @@
-import { FC, KeyboardEventHandler } from 'react';
+import { FC, useEffect } from 'react';
 import { useFullScreen } from 'components/hooks';
 import { Button } from 'components/button';
 import styles from './fullscreen-button.module.pcss';
@@ -8,18 +8,18 @@ export const FullScreenButton: FC<{ fsRef: Nullable<HTMLElement> }> = ({
 }) => {
   const { isFullScreen, toggleFullScreen } = useFullScreen(fsRef);
 
-  const handleKeyDown: KeyboardEventHandler<HTMLButtonElement> = (e) => {
-    if (e.key === 'f') {
-      toggleFullScreen();
-    }
-  };
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (e.key === 'f' || e.key === 'F') {
+        toggleFullScreen();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [toggleFullScreen]);
 
   return (
-    <Button
-      onClick={toggleFullScreen}
-      onKeyDown={handleKeyDown}
-      className={styles.button}
-    >
+    <Button onClick={toggleFullScreen} className={styles.button}>
       {isFullScreen ? 'свернуть' : 'развернуть на весь экран'}
     </Button>
   );

--- a/packages/client/src/components/fullscreen-button/fullscreen-button.tsx
+++ b/packages/client/src/components/fullscreen-button/fullscreen-button.tsx
@@ -1,0 +1,26 @@
+import { FC, KeyboardEventHandler } from 'react';
+import { useFullScreen } from 'components/hooks';
+import { Button } from 'components/button';
+import styles from './fullscreen-button.module.pcss';
+
+export const FullScreenButton: FC<{ fsRef: Nullable<HTMLElement> }> = ({
+  fsRef,
+}) => {
+  const { isFullScreen, toggleFullScreen } = useFullScreen(fsRef);
+
+  const handleKeyDown: KeyboardEventHandler<HTMLButtonElement> = (e) => {
+    if (e.key === 'f') {
+      toggleFullScreen();
+    }
+  };
+
+  return (
+    <Button
+      onClick={toggleFullScreen}
+      onKeyDown={handleKeyDown}
+      className={styles.button}
+    >
+      {isFullScreen ? 'свернуть' : 'развернуть на весь экран'}
+    </Button>
+  );
+};

--- a/packages/client/src/components/fullscreen-button/index.ts
+++ b/packages/client/src/components/fullscreen-button/index.ts
@@ -1,0 +1,1 @@
+export { FullScreenButton } from './fullscreen-button';

--- a/packages/client/src/components/game-view/game-view.module.pcss
+++ b/packages/client/src/components/game-view/game-view.module.pcss
@@ -1,7 +1,15 @@
+.fullscreen {
+  &:fullscreen {
+    background-color: var(--color-primary-white, #fff);
+    padding: var(--gap);
+  }
+}
+
 .game {
   display: grid;
   grid-template-columns: 98px 1fr;
   gap: 24px;
+  height: 100vh;
 }
 
 .points {

--- a/packages/client/src/components/game-view/game-view.tsx
+++ b/packages/client/src/components/game-view/game-view.tsx
@@ -11,6 +11,7 @@ import { ColorPicker } from 'components/color-picker';
 import { renderPath } from './utils/render-path';
 import { gameDataAleksa as gameData } from './utils/game-data';
 import { formColors } from './utils/form-colors';
+import { FullScreenButton } from 'components/fullscreen-button';
 
 const HARD_CODE_POINTS = '2440';
 const HARD_CODE_TIME = '2м:39с';
@@ -29,6 +30,7 @@ export const GameView: FC<{ gameId?: string }> = ({ gameId }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const fieldRef = useRef<HTMLDivElement>(null);
   const resizableRef = useRef<HTMLDivElement>(null);
+  const gameRef = useRef<HTMLDivElement>(null);
 
   if (!gameId) {
     throw new Error(`no game found by id: ${gameId} `);
@@ -159,10 +161,11 @@ export const GameView: FC<{ gameId?: string }> = ({ gameId }) => {
   };
 
   return (
-    <div>
+    <div ref={gameRef} className={styles.fullscreen}>
       <div className={styles.points}>
         <p className="text-menu">{HARD_CODE_POINTS}</p>
         <p className="text-menu">{HARD_CODE_TIME}</p>
+        {gameRef.current && <FullScreenButton fsRef={gameRef.current} />}
       </div>
 
       <div className={styles.game}>

--- a/packages/client/src/components/hooks/index.ts
+++ b/packages/client/src/components/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useFullScreen } from './use-fullscreen';

--- a/packages/client/src/components/hooks/use-fullscreen.ts
+++ b/packages/client/src/components/hooks/use-fullscreen.ts
@@ -18,27 +18,27 @@ interface VendorElement extends HTMLElement {
   msRequestFullscreen?: () => void;
 }
 
-const d = document as VendorDocument;
-const dEl = d.documentElement as VendorElement;
+const vendorDocument = document as VendorDocument;
+const vendorDocumentElement = vendorDocument.documentElement as VendorElement;
 
 function isFullScreenElement(el?: Nullable<VendorElement>) {
   if (el) {
     return Boolean(
-      d.fullscreenElement === el ||
-        d.mozFullScreenElement === el ||
-        d.webkitFullscreenElement === el ||
-        d.msFullscreenElement === el
+      vendorDocument.fullscreenElement === el ||
+        vendorDocument.mozFullScreenElement === el ||
+        vendorDocument.webkitFullscreenElement === el ||
+        vendorDocument.msFullscreenElement === el
     );
   }
 
   return Boolean(
-    d.fullscreenElement ||
-      d.mozFullScreenElement ||
-      d.webkitFullscreenElement ||
-      d.msFullscreenElement ||
-      d.mozFullScreen ||
-      d.webkitIsFullScreen ||
-      d.fullScreenMode
+    vendorDocument.fullscreenElement ||
+      vendorDocument.mozFullScreenElement ||
+      vendorDocument.webkitFullscreenElement ||
+      vendorDocument.msFullscreenElement ||
+      vendorDocument.mozFullScreen ||
+      vendorDocument.webkitIsFullScreen ||
+      vendorDocument.fullScreenMode
   );
 }
 
@@ -47,7 +47,7 @@ export const useFullScreen = (fsEl: Nullable<VendorElement>) => {
   const [isFullScreen, setIsFullScreen] = useState(initialState);
 
   const openFullScreen = () => {
-    const el = fsEl || dEl;
+    const el = fsEl || vendorDocumentElement;
     if (!el) return;
 
     const requestFullscreen =
@@ -61,10 +61,10 @@ export const useFullScreen = (fsEl: Nullable<VendorElement>) => {
 
   const closeFullScreen = () => {
     const exitFullScreen =
-      d.exitFullscreen ||
-      d.webkitExitFullscreen ||
-      d.mozCancelFullScreen ||
-      d.msExitFullscreen;
+      vendorDocument.exitFullscreen ||
+      vendorDocument.webkitExitFullscreen ||
+      vendorDocument.mozCancelFullScreen ||
+      vendorDocument.msExitFullscreen;
 
     return exitFullScreen.call(document);
   };
@@ -74,18 +74,42 @@ export const useFullScreen = (fsEl: Nullable<VendorElement>) => {
   }, [fsEl]);
 
   useEffect(() => {
-    d.addEventListener('webkitfullscreenchange', handleChange, false);
-    d.addEventListener('mozfullscreenchange', handleChange, false);
-    d.addEventListener('msfullscreenchange', handleChange, false);
-    d.addEventListener('MSFullscreenChange', handleChange, false);
-    d.addEventListener('fullscreenchange', handleChange, false);
+    vendorDocument.addEventListener(
+      'webkitfullscreenchange',
+      handleChange,
+      false
+    );
+    vendorDocument.addEventListener('mozfullscreenchange', handleChange, false);
+    vendorDocument.addEventListener('msfullscreenchange', handleChange, false);
+    vendorDocument.addEventListener('MSFullscreenChange', handleChange, false);
+    vendorDocument.addEventListener('fullscreenchange', handleChange, false);
 
     return () => {
-      d.removeEventListener('webkitfullscreenchange', handleChange);
-      d.removeEventListener('mozfullscreenchange', handleChange);
-      d.removeEventListener('msfullscreenchange', handleChange);
-      d.removeEventListener('MSFullscreenChange', handleChange);
-      d.removeEventListener('fullscreenchange', handleChange);
+      vendorDocument.removeEventListener(
+        'webkitfullscreenchange',
+        handleChange,
+        false
+      );
+      vendorDocument.removeEventListener(
+        'mozfullscreenchange',
+        handleChange,
+        false
+      );
+      vendorDocument.removeEventListener(
+        'msfullscreenchange',
+        handleChange,
+        false
+      );
+      vendorDocument.removeEventListener(
+        'MSFullscreenChange',
+        handleChange,
+        false
+      );
+      vendorDocument.removeEventListener(
+        'fullscreenchange',
+        handleChange,
+        false
+      );
     };
   }, [fsEl, handleChange]);
 

--- a/packages/client/src/components/hooks/use-fullscreen.ts
+++ b/packages/client/src/components/hooks/use-fullscreen.ts
@@ -1,0 +1,98 @@
+import { useState, useEffect, useCallback } from 'react';
+
+interface VendorDocument extends Document {
+  mozFullScreenElement?: Nullable<Element>;
+  webkitFullscreenElement?: Nullable<Element>;
+  msFullscreenElement?: Nullable<Element>;
+  mozFullScreen?: boolean;
+  webkitIsFullScreen?: boolean;
+  fullScreenMode?: boolean;
+  webkitExitFullscreen?: () => void;
+  mozCancelFullScreen?: () => void;
+  msExitFullscreen?: () => void;
+}
+
+interface VendorElement extends HTMLElement {
+  webkitRequestFullScreen?: () => void;
+  mozRequestFullScreen?: () => void;
+  msRequestFullscreen?: () => void;
+}
+
+const d = document as VendorDocument;
+const dEl = d.documentElement as VendorElement;
+
+function isFullScreenElement(el?: Nullable<VendorElement>) {
+  if (el) {
+    return Boolean(
+      d.fullscreenElement === el ||
+        d.mozFullScreenElement === el ||
+        d.webkitFullscreenElement === el ||
+        d.msFullscreenElement === el
+    );
+  }
+
+  return Boolean(
+    d.fullscreenElement ||
+      d.mozFullScreenElement ||
+      d.webkitFullscreenElement ||
+      d.msFullscreenElement ||
+      d.mozFullScreen ||
+      d.webkitIsFullScreen ||
+      d.fullScreenMode
+  );
+}
+
+export const useFullScreen = (fsEl: Nullable<VendorElement>) => {
+  const initialState = window ? false : isFullScreenElement(fsEl);
+  const [isFullScreen, setIsFullScreen] = useState(initialState);
+
+  const openFullScreen = () => {
+    const el = fsEl || dEl;
+    if (!el) return;
+
+    const requestFullscreen =
+      el.requestFullscreen ||
+      el.webkitRequestFullScreen ||
+      el.mozRequestFullScreen ||
+      el.msRequestFullscreen;
+
+    return requestFullscreen.call(el);
+  };
+
+  const closeFullScreen = () => {
+    const exitFullScreen =
+      d.exitFullscreen ||
+      d.webkitExitFullscreen ||
+      d.mozCancelFullScreen ||
+      d.msExitFullscreen;
+
+    return exitFullScreen.call(document);
+  };
+
+  const handleChange = useCallback(() => {
+    setIsFullScreen(isFullScreenElement(fsEl));
+  }, [fsEl]);
+
+  useEffect(() => {
+    d.addEventListener('webkitfullscreenchange', handleChange, false);
+    d.addEventListener('mozfullscreenchange', handleChange, false);
+    d.addEventListener('msfullscreenchange', handleChange, false);
+    d.addEventListener('MSFullscreenChange', handleChange, false);
+    d.addEventListener('fullscreenchange', handleChange, false);
+
+    return () => {
+      d.removeEventListener('webkitfullscreenchange', handleChange);
+      d.removeEventListener('mozfullscreenchange', handleChange);
+      d.removeEventListener('msfullscreenchange', handleChange);
+      d.removeEventListener('MSFullscreenChange', handleChange);
+      d.removeEventListener('fullscreenchange', handleChange);
+    };
+  }, [fsEl, handleChange]);
+
+  return {
+    isFullScreen,
+    open: openFullScreen,
+    close: closeFullScreen,
+    toggleFullScreen: isFullScreen ? closeFullScreen : openFullScreen,
+  };
+};

--- a/packages/client/typings/app.d.ts
+++ b/packages/client/typings/app.d.ts
@@ -28,6 +28,8 @@ declare global {
     phone: string;
     email: string;
   };
+
+  export type Nullable<T> = T | null;
 }
 
 export {};


### PR DESCRIPTION
### Какую задачу решаем
- добавлен хук `useFullScreen` и компонент `FullScreenButton`. В хук не обязательно передавать конкретный элемент для перевода в fullscreen, тогда переведется `documentElement`
- на всякий случай хук возвращает как состояние `isFullscreen`, так и три метода `toggleFullScreen, open, close`

### Скриншоты/видяшка (если есть)

https://user-images.githubusercontent.com/65237410/224259757-98615112-e3ee-405d-95a9-8503b454214c.mp4

### TBD
- сделать тоглер кнопкой-иконкой 