### PR TITLE
Доп. настройка jest и eslint

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  projects: ['<rootDir>/packages/client', '<rootDir>/packages/server'],
+};

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,8 +11,7 @@ pre-commit:
         yarn stylelint --fix {staged_files} &&
         yarn prettier --write --loglevel warn {staged_files} &&
         git add {staged_files}
-    lint:js:client:
-      root: 'packages/client/'
+    lint:js:
       glob: '*.{ts,tsx}'
       exclude: '^(.*)\.(spec|test)\.tsx?'
       env:
@@ -22,29 +21,7 @@ pre-commit:
         yarn prettier --write --loglevel warn {staged_files} &&
         yarn jest --bail --findRelatedTests --passWithNoTests {staged_files} &&
         git add {staged_files}
-    lint:js:server:
-      root: 'packages/server/'
-      glob: '*.{ts,tsx}'
-      exclude: '^(.*)\.(spec|test)\.tsx?'
-      env:
-        PRE_COMMIT: true
-      run: >
-        yarn eslint --fix --max-warnings=0 {staged_files} &&
-        yarn prettier --write --loglevel warn {staged_files} &&
-        yarn jest --bail --findRelatedTests --passWithNoTests {staged_files} &&
-        git add {staged_files}
-    test:unit:client:
-      root: 'packages/client/'
-      glob: '*.{spec,test}.{ts,tsx}'
-      env:
-        PRE_COMMIT: true
-      run: >
-        yarn eslint --fix {staged_files} &&
-        yarn prettier --write --loglevel warn {staged_files} &&
-        yarn jest {staged_files} &&
-        git add {staged_files}
-    test:unit:server:
-      root: 'packages/server/'
+    test:unit:
       glob: '*.{spec,test}.{ts,tsx}'
       env:
         PRE_COMMIT: true

--- a/packages/client/.eslintrc.cjs
+++ b/packages/client/.eslintrc.cjs
@@ -20,4 +20,13 @@ module.exports = {
     'react/jsx-boolean-value': ['error', 'never'],
     'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
   },
+  overrides: [
+    {
+      files: ['?(*.)+(spec|test).tsx'],
+      extends: ['plugin:jest-dom/recommended', 'plugin:testing-library/react'],
+      rules: {
+        'testing-library/prefer-screen-queries': 'off',
+      },
+    },
+  ],
 };

--- a/packages/client/.eslintrc.cjs
+++ b/packages/client/.eslintrc.cjs
@@ -26,6 +26,11 @@ module.exports = {
       extends: ['plugin:jest-dom/recommended', 'plugin:testing-library/react'],
       rules: {
         'testing-library/prefer-screen-queries': 'off',
+        'testing-library/prefer-wait-for': 'error',
+        'testing-library/prefer-user-event': [
+          'error',
+          { allowedMethods: ['click'] },
+        ],
       },
     },
   ],

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -1,15 +1,17 @@
-/* eslint-disable @typescript-eslint/naming-convention */
+/** @type {import('jest').Config} */
 import dotenv from 'dotenv';
 dotenv.config();
 
 export default {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  displayName: 'CLIENT',
   testMatch: ['<rootDir>/src/**/*.test.{ts,tsx}'],
   globals: {
     __SERVER_PORT__: process.env.SERVER_PORT,
   },
   setupFiles: ['<rootDir>/test/setup-env.ts'],
+  setupFilesAfterEnv: ['<rootDir>/test/jest-setup.ts'],
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',
@@ -34,7 +36,10 @@ export default {
       },
     ],
   },
+  transformIgnorePatterns: ['/node_modules/(?!swiper|ssr-window|dom7)'],
   moduleNameMapper: {
+    '\\.(p?css|jpe?g|png|webp)$': 'identity-obj-proxy',
+    '\\.svg$': '<rootDir>/test/mocks/svg.ts',
     '^src/(.*)$': '<rootDir>/src/$1',
     '^components/(.*)$': '<rootDir>/src/components/$1',
     '^pages/(.*)$': '<rootDir>/src/pages/$1',
@@ -42,6 +47,5 @@ export default {
     '^styles/(.*)$': '<rootDir>/src/styles/$1',
     '^api/(.*)$': '<rootDir>/src/api/$1',
     '^assets/(.*)$': '<rootDir>/src/assets/$1',
-    '\\.(pcss)$': 'identity-obj-proxy',
   },
 };

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,7 +30,9 @@
     "swiper": "9.1.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "14.0.0",
+    "@testing-library/user-event": "14.4.3",
     "@types/jest": "29.4.0",
     "@types/react": "18.0.18",
     "@types/react-dom": "18.0.11",
@@ -39,9 +41,11 @@
     "cross-env": "7.0.3",
     "eslint": "8.34.0",
     "eslint-config-shared": "*",
+    "eslint-plugin-jest-dom": "4.0.3",
     "eslint-plugin-jsx-a11y": "6.7.1",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "4.6.0",
+    "eslint-plugin-testing-library": "5.10.2",
     "identity-obj-proxy": "3.0.0",
     "jest": "29.4.3",
     "jest-environment-jsdom": "29.4.3",

--- a/packages/client/src/app.test.tsx
+++ b/packages/client/src/app.test.tsx
@@ -1,8 +1,0 @@
-// @ts-ignore
-global.fetch = jest.fn(() =>
-  Promise.resolve({ json: () => Promise.resolve('hey') })
-);
-
-test('Example test', async () => {
-  expect(true).toBe(true);
-});

--- a/packages/client/src/components/tabs/tabs.module.pcss
+++ b/packages/client/src/components/tabs/tabs.module.pcss
@@ -7,8 +7,16 @@
   margin: 0;
 }
 
-.tabItem {
+.control {
   position: relative;
+  padding: 6px 0;
+  border: 0;
+  background: 0 0;
+  font-size: 16px;
+  white-space: nowrap;
+  appearance: none;
+  cursor: pointer;
+  overflow: visible;
 
   &::after {
     content: '';
@@ -25,15 +33,4 @@
   &.active::after {
     opacity: 1;
   }
-}
-
-.control {
-  padding: 6px 0;
-  border: 0;
-  background: 0 0;
-  font-size: 16px;
-  white-space: nowrap;
-  appearance: none;
-  cursor: pointer;
-  overflow: visible;
 }

--- a/packages/client/src/components/tabs/tabs.test.tsx
+++ b/packages/client/src/components/tabs/tabs.test.tsx
@@ -1,0 +1,63 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Tabs } from './tabs';
+
+describe('components/Tabs', () => {
+  const tabs = [
+    {
+      key: 'test-1',
+      label: 'Test 1',
+    },
+    {
+      key: 'test-2',
+      label: 'Test 2',
+    },
+  ];
+
+  it('should render tabs', () => {
+    const view = render(
+      <Tabs tabs={tabs} activeTab="test-1" onChange={jest.fn} />
+    );
+
+    expect(view.getByRole('button', { name: 'Test 1' })).toBeInTheDocument();
+    expect(view.getByRole('button', { name: 'Test 2' })).toBeInTheDocument();
+    expect(view.getAllByRole('button')).toHaveLength(2);
+  });
+
+  it('should fire `onChange` event', async () => {
+    const user = userEvent.setup();
+    const onChangeFn = jest.fn();
+    const view = render(
+      <Tabs tabs={tabs} activeTab="test-1" onChange={onChangeFn} />
+    );
+
+    await user.click(view.getByRole('button', { name: 'Test 2' }));
+
+    expect(onChangeFn).toHaveBeenCalledTimes(1);
+    expect(onChangeFn).toHaveBeenCalledWith('test-2');
+  });
+
+  it('should render active tab', () => {
+    const view = render(
+      <Tabs tabs={tabs} activeTab="test-2" onChange={jest.fn} />
+    );
+
+    expect(view.getByRole('button', { name: 'Test 2' })).toHaveClass('active');
+  });
+
+  it('should change active tab', () => {
+    const mockFn = jest.fn();
+    const view = render(
+      <Tabs tabs={tabs} activeTab="test-2" onChange={mockFn} />
+    );
+
+    expect(view.getByRole('button', { name: 'Test 2' })).toHaveClass('active');
+
+    view.rerender(<Tabs tabs={tabs} activeTab="test-1" onChange={mockFn} />);
+
+    expect(view.getByRole('button', { name: 'Test 1' })).toHaveClass('active');
+    expect(view.getByRole('button', { name: 'Test 2' })).not.toHaveClass(
+      'active'
+    );
+  });
+});

--- a/packages/client/src/components/tabs/tabs.tsx
+++ b/packages/client/src/components/tabs/tabs.tsx
@@ -18,14 +18,11 @@ export const Tabs: FC<Props> = ({ tabs, activeTab, onChange }) => {
     <ul className={styles.tabs}>
       {tabs.map(({ key, label }) => {
         return (
-          <li
-            className={cn(styles.tabItem, {
-              [styles.active]: key === activeTab,
-            })}
-            key={key}
-          >
+          <li className={styles.tabItem} key={key}>
             <button
-              className={styles.control}
+              className={cn(styles.conrol, {
+                [styles.active]: key === activeTab,
+              })}
               type="button"
               onClick={() => onChange(key)}
             >

--- a/packages/client/src/components/tabs/tabs.tsx
+++ b/packages/client/src/components/tabs/tabs.tsx
@@ -20,7 +20,7 @@ export const Tabs: FC<Props> = ({ tabs, activeTab, onChange }) => {
         return (
           <li className={styles.tabItem} key={key}>
             <button
-              className={cn(styles.conrol, {
+              className={cn(styles.control, {
                 [styles.active]: key === activeTab,
               })}
               type="button"

--- a/packages/client/test/jest-setup.ts
+++ b/packages/client/test/jest-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/packages/client/test/mocks/svg.ts
+++ b/packages/client/test/mocks/svg.ts
@@ -1,0 +1,2 @@
+export default 'SvgrURL';
+export const ReactComponent = 'div';

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
     port: Number(process.env.CLIENT_PORT) || 3000,
   },
   define: {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     __SERVER_PORT__: process.env.SERVER_PORT,
   },
   plugins: [
@@ -32,7 +31,6 @@ export default defineConfig({
       svgrOptions: {
         typescript: true,
         replaceAttrValues: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           '#000': 'currentColor',
           black: 'currentColor',
         },

--- a/packages/eslint-config-shared/index.js
+++ b/packages/eslint-config-shared/index.js
@@ -25,6 +25,7 @@ module.exports = {
         'max-statements': 'off',
         'require-await': 'off',
         '@typescript-eslint/ban-ts-comment': 'off',
+        '@typescript-eslint/no-empty-function': 'off',
       },
     },
     {

--- a/packages/server/jest.config.js
+++ b/packages/server/jest.config.js
@@ -1,4 +1,6 @@
+/** @type {import('jest').Config} */
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-}
+  displayName: 'SERVER',
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adobe/css-tools@^4.0.1":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.2.0.tgz#e1a84fca468f4b337816fcb7f0964beb620ba855"
+  integrity sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==
+
 "@ampproject/remapping@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -274,7 +279,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.19.0"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.20.7":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.20.7", "@babel/runtime@^7.9.2":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -1300,6 +1305,20 @@
     "@svgr/hast-util-to-babel-ast" "^6.5.1"
     svg-parser "^2.0.4"
 
+"@testing-library/dom@^8.11.1":
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.20.0.tgz#914aa862cef0f5e89b98cc48e3445c4c921010f6"
+  integrity sha512-d9ULIT+a4EXLX3UU8FBjauG9NnsZHkHztXoIcTsOKoOw030fyjheN9svkTULjJxtYag9DZz5Jz5qkWZDPxTFwA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
 "@testing-library/dom@^9.0.0":
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.0.0.tgz#cc50e8df2a7dccff95555102beebbae60e95e95e"
@@ -1314,6 +1333,21 @@
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
+"@testing-library/jest-dom@5.16.5":
+  version "5.16.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz#3912846af19a29b2dbf32a6ae9c31ef52580074e"
+  integrity sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==
+  dependencies:
+    "@adobe/css-tools" "^4.0.1"
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^5.0.0"
+    chalk "^3.0.0"
+    css.escape "^1.5.1"
+    dom-accessibility-api "^0.5.6"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
 "@testing-library/react@14.0.0":
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.0.0.tgz#59030392a6792450b9ab8e67aea5f3cc18d6347c"
@@ -1322,6 +1356,11 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^9.0.0"
     "@types/react-dom" "^18.0.0"
+
+"@testing-library/user-event@14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -1456,7 +1495,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@29.4.0":
+"@types/jest@*", "@types/jest@29.4.0":
   version "29.4.0"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.4.0.tgz#a8444ad1704493e84dbf07bb05990b275b3b9206"
   integrity sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==
@@ -1585,6 +1624,13 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.14.5"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz#d113709c90b3c75fdb127ec338dad7d5f86c974f"
+  integrity sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==
+  dependencies:
+    "@types/jest" "*"
+
 "@types/tough-cookie@*":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
@@ -1644,6 +1690,14 @@
     "@typescript-eslint/types" "5.54.0"
     "@typescript-eslint/visitor-keys" "5.54.0"
 
+"@typescript-eslint/scope-manager@5.54.1":
+  version "5.54.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.54.1.tgz#6d864b4915741c608a58ce9912edf5a02bb58735"
+  integrity sha512-zWKuGliXxvuxyM71UA/EcPxaviw39dB2504LqAmFDjmkpO8qNLHcmzlh6pbHs1h/7YQ9bnsO8CCcYCSA8sykUg==
+  dependencies:
+    "@typescript-eslint/types" "5.54.1"
+    "@typescript-eslint/visitor-keys" "5.54.1"
+
 "@typescript-eslint/type-utils@5.53.0":
   version "5.53.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.53.0.tgz#41665449935ba9b4e6a1ba6e2a3f4b2c31d6cf97"
@@ -1663,6 +1717,11 @@
   version "5.54.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.54.0.tgz#7d519df01f50739254d89378e0dcac504cab2740"
   integrity sha512-nExy+fDCBEgqblasfeE3aQ3NuafBUxZxgxXcYfzYRZFHdVvk5q60KhCSkG0noHgHRo/xQ/BOzURLZAafFpTkmQ==
+
+"@typescript-eslint/types@5.54.1":
+  version "5.54.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.54.1.tgz#29fbac29a716d0f08c62fe5de70c9b6735de215c"
+  integrity sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==
 
 "@typescript-eslint/typescript-estree@5.53.0":
   version "5.53.0"
@@ -1684,6 +1743,19 @@
   dependencies:
     "@typescript-eslint/types" "5.54.0"
     "@typescript-eslint/visitor-keys" "5.54.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.54.1":
+  version "5.54.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.1.tgz#df7b6ae05fd8fef724a87afa7e2f57fa4a599be1"
+  integrity sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==
+  dependencies:
+    "@typescript-eslint/types" "5.54.1"
+    "@typescript-eslint/visitor-keys" "5.54.1"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -1718,6 +1790,20 @@
     eslint-utils "^3.0.0"
     semver "^7.3.7"
 
+"@typescript-eslint/utils@^5.43.0":
+  version "5.54.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.54.1.tgz#7a3ee47409285387b9d4609ea7e1020d1797ec34"
+  integrity sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.54.1"
+    "@typescript-eslint/types" "5.54.1"
+    "@typescript-eslint/typescript-estree" "5.54.1"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+    semver "^7.3.7"
+
 "@typescript-eslint/visitor-keys@5.53.0":
   version "5.53.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz#8a5126623937cdd909c30d8fa72f79fa56cc1a9f"
@@ -1732,6 +1818,14 @@
   integrity sha512-xu4wT7aRCakGINTLGeyGqDn+78BwFlggwBjnHa1ar/KaGagnmwLYmlrXIrgAaQ3AE1Vd6nLfKASm7LrFHNbKGA==
   dependencies:
     "@typescript-eslint/types" "5.54.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.54.1":
+  version "5.54.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.1.tgz#d7a8a0f7181d6ac748f4d47b2306e0513b98bf8b"
+  integrity sha512-q8iSoHTgwCfgcRJ2l2x+xCbu8nBlRAlsQ33k24Adj8eoVBE0f8dUeI+bAa8F84Mv05UGbAx57g2zrRsYIooqQg==
+  dependencies:
+    "@typescript-eslint/types" "5.54.1"
     eslint-visitor-keys "^3.3.0"
 
 "@vitejs/plugin-react@3.1.0":
@@ -2367,6 +2461,14 @@ chalk@^2.0.0, chalk@^2.4.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -2802,6 +2904,11 @@ css-tree@^2.3.1:
     mdn-data "2.0.30"
     source-map-js "^1.0.1"
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
+
 cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
@@ -3034,7 +3141,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.9:
+dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
@@ -3317,6 +3424,15 @@ eslint-plugin-es@^3.0.0:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
 
+eslint-plugin-jest-dom@4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-4.0.3.tgz#ec17171385660e78465cce9f3e1ce90294ea1190"
+  integrity sha512-9j+n8uj0+V0tmsoS7bYC7fLhQmIvjRqRYEcbDSi+TKPsTThLLXCyj5swMSSf/hTleeMktACnn+HFqXBr5gbcbA==
+  dependencies:
+    "@babel/runtime" "^7.16.3"
+    "@testing-library/dom" "^8.11.1"
+    requireindex "^1.2.0"
+
 eslint-plugin-jest@27.2.1:
   version "27.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz#b85b4adf41c682ea29f1f01c8b11ccc39b5c672c"
@@ -3388,6 +3504,13 @@ eslint-plugin-react@7.32.2:
     resolve "^2.0.0-next.4"
     semver "^6.3.0"
     string.prototype.matchall "^4.0.8"
+
+eslint-plugin-testing-library@5.10.2:
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.10.2.tgz#12f231ad9b52b6aef45c801fd00aa129a932e0c2"
+  integrity sha512-f1DmDWcz5SDM+IpCkEX0lbFqrrTs8HRsEElzDEqN/EBI0hpRj8Cns5+IVANXswE8/LeybIJqPAOQIFu2j5Y5sw==
+  dependencies:
+    "@typescript-eslint/utils" "^5.43.0"
 
 eslint-plugin-unicorn@45.0.2:
   version "45.0.2"
@@ -7224,6 +7347,11 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+requireindex@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### Какую задачу решаем
Настройка окружения для тестирования

- упростил lefthook конфиг. Работает как и раньше, только теперь jest конфиги пакетов (client, server) резолвятся через корневой `jest.config.js`, а не через смену cwd в lefthook.
- добавил [`eslint-plugin-testing-library`](https://github.com/testing-library/eslint-plugin-testing-library), [`eslint-plugin-jest-dom`](https://github.com/testing-library/eslint-plugin-jest-dom) подсказывающие лучшие практики при написании юнит тестов.
- добавил [`@testing-library/jest-dom`](https://github.com/testing-library/jest-dom) - jest матчеры для DOM
- добавил [`@testing-library/user-event`](https://github.com/testing-library/user-event) - библиотека для симуляции взаимодействия с DOM (клики, ховеры, набор текста) 
- добавил юнит тест компонента `Tabs`